### PR TITLE
This filter is absolutely useless

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -160,8 +160,8 @@ www.chosun.com###sec_health > .sec_sub > .sec_sub_ad
 @@/omniture/$script,domain=goal.com
 /openads/adjs.php^
 /openads/adx.js
-/overture/
-/overture_
+! /overture/
+! /overture_
 /pato/index.php?count_add=
 /piwik.js$domain=~apple.com
 /pv_iframe.htm^


### PR DESCRIPTION
It's seems like not actually necessary. However, for future update, I edit it as ignored filter rule.

Edited 
/overture/ and /overture_ 
as
! /overture/ and ! /overture_